### PR TITLE
Scheduling improvements

### DIFF
--- a/crates/kiwi-syscall/src/ipc.rs
+++ b/crates/kiwi-syscall/src/ipc.rs
@@ -57,6 +57,12 @@ pub enum SendError {
 
     /// The payload size exceeds the maximum allowed size.
     PayloadTooLarge = 3,
+
+    /// The target task does not exist.
+    TaskDoesNotExist = 4,
+
+    /// The target task has been destroyed before the message could be sent.
+    TaskDestroyed = 5,
 }
 
 impl From<SendError> for isize {
@@ -66,6 +72,8 @@ impl From<SendError> for isize {
             SendError::InvalidDestination => 1,
             SendError::BadMessage => 2,
             SendError::PayloadTooLarge => 3,
+            SendError::TaskDoesNotExist => 4,
+            SendError::TaskDestroyed => 5,
         }
     }
 }
@@ -106,6 +114,15 @@ pub enum ReplyError {
 
     /// The task is not waiting for a reply from the sender.
     NotWaitingForReply = 4,
+
+    /// The receiver expected a reply from a different sender.
+    UnexpectedSender = 5,
+
+    /// The target task does not exist.
+    TaskDoesNotExist = 6,
+
+    /// The target task has been destroyed before the reply could be sent.
+    TaskDestroyed = 7,
 }
 
 impl From<ReplyError> for isize {
@@ -116,6 +133,9 @@ impl From<ReplyError> for isize {
             ReplyError::BadMessage => 2,
             ReplyError::PayloadTooLarge => 3,
             ReplyError::NotWaitingForReply => 4,
+            ReplyError::UnexpectedSender => 5,
+            ReplyError::TaskDoesNotExist => 6,
+            ReplyError::TaskDestroyed => 7,
         }
     }
 }

--- a/kernel/src/arch/generic/timer.rs
+++ b/kernel/src/arch/generic/timer.rs
@@ -25,3 +25,18 @@ pub fn internal_frequency() -> u64 {
 pub fn internal_tick() -> u64 {
     crate::arch::target::timer::internal_tick()
 }
+
+/// Get the current time since the system booted, in internal ticks.
+#[must_use]
+pub fn current_time_ticks() -> u64 {
+    crate::arch::target::timer::current_time_ticks()
+}
+
+/// Get the current time since the system booted, as a `Duration`.
+#[must_use]
+pub fn since_boot() -> core::time::Duration {
+    let ticks = current_time_ticks();
+    let tick_duration = internal_tick();
+
+    core::time::Duration::from_nanos(ticks * tick_duration)
+}

--- a/kernel/src/arch/riscv64/timer.rs
+++ b/kernel/src/arch/riscv64/timer.rs
@@ -63,3 +63,9 @@ pub fn internal_frequency() -> u64 {
 pub fn internal_tick() -> u64 {
     INTERNAL_TICK.read()
 }
+
+/// Get the current time since the system booted, in internal ticks.
+#[must_use]
+pub fn current_time_ticks() -> u64 {
+    riscv::register::time::read64()
+}

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -19,18 +19,16 @@ pub const MAX_TASKS: u16 = 32;
 /// not waste too much memory since the stack is only allocated once per CPU.
 pub const KERNEL_STACK_SIZE: usize = 4096 * 4;
 
-/// The number of milliseconds that a thread can run before being preempted
-/// by the scheduler if it has not yielded the CPU. This value is used to
-/// prevent a single thread from monopolizing the CPU.
+/// The number of milliseconds that a thread can run continuously before being
+/// preempted if it does not yield voluntarily. This value is used to set the
+/// timer interrupt frequency for thread scheduling. A smaller value will lead to
+/// more frequent context switches, which can improve responsiveness but also
+/// increase overhead. A larger value will reduce context switch overhead but
+/// may lead to less responsive multitasking.
 ///
-/// The value of 25 milliseconds is chosen because it is a good balance
-/// between responsiveness and performance. A lower value would make the
-/// system more responsive, but it would also increase the number of context
-/// switches, which would reduce the overall throughput of the system and
-/// increase the overhead of the scheduler. A higher value would reduce the
-/// number of context switches and reduce the overhead of the scheduler, but
-/// it would also make the system less responsive.
-///
-/// Depending on the use case, this value can be adjusted to better fit the
-/// requirements of the system.
-pub const THREAD_QUANTUM: u64 = 25;
+/// The current value of 25 milliseconds is a reasonable compromise for general
+/// purpose computing. It provides a good balance between responsiveness and
+/// overhead for most workloads. However, this value may need to be adjusted
+/// based on the specific requirements of the system and the nature of the tasks
+/// being run.
+pub const THREAD_MAX_RUN_DURATION: u64 = 25;

--- a/kernel/src/config.rs
+++ b/kernel/src/config.rs
@@ -1,3 +1,5 @@
+use core::time::Duration;
+
 /// The maximum number of tasks that can be created. The kernel will use this
 /// constant to allocate memory for the task control blocks and other data
 /// during initialization. Diminishing this value will reduce the memory usage
@@ -31,4 +33,4 @@ pub const KERNEL_STACK_SIZE: usize = 4096 * 4;
 /// overhead for most workloads. However, this value may need to be adjusted
 /// based on the specific requirements of the system and the nature of the tasks
 /// being run.
-pub const THREAD_MAX_RUN_DURATION: u64 = 25;
+pub const THREAD_MAX_RUN_DURATION: Duration = Duration::from_millis(25);

--- a/kernel/src/future/mod.rs
+++ b/kernel/src/future/mod.rs
@@ -8,6 +8,7 @@ pub mod executor;
 pub mod mutex;
 pub mod task;
 pub mod user;
+pub mod wait;
 pub mod waker;
 
 /// A future that yields once before completing. This future can be useful

--- a/kernel/src/future/task.rs
+++ b/kernel/src/future/task.rs
@@ -1,13 +1,20 @@
 use crate::{
-    future::{executor::Executor, waker::Waker},
-    time,
+    future::{self, executor::Executor, waker::Waker},
+    ipc, time,
 };
 use alloc::{boxed::Box, sync::Arc};
 use core::{
     future::Future,
+    hash::Hash,
     pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
 };
+use hashbrown::HashMap;
+use spin::{Lazy, RwLock};
+
+/// The local data associated with each task.
+static TASK_LOCAL_DATA_MAP: Lazy<RwLock<HashMap<Identifier, LocalDataSet>>> =
+    Lazy::new(|| RwLock::new(HashMap::new()));
 
 /// A task that can be executed by an executor.
 pub struct Task<'a> {
@@ -32,7 +39,8 @@ pub struct Task<'a> {
 }
 
 impl<'a> Task<'a> {
-    /// Creates a new task with the given executor and future.
+    /// Creates a new task with the given executor and future. It also creates
+    /// the local data set for the task.
     pub fn new(
         executor: &'a Executor<'a>,
         future: Pin<Box<dyn Future<Output = ()> + Send>>,
@@ -40,6 +48,12 @@ impl<'a> Task<'a> {
     ) -> Self {
         let id = Identifier::generate();
         let waker = Arc::new(Waker::new(Arc::clone(executor.ready_ids()), id));
+
+        // Create the local data set for the task
+        TASK_LOCAL_DATA_MAP
+            .write()
+            .insert(id, LocalDataSet::default());
+
         Self {
             executor,
             future,
@@ -84,6 +98,13 @@ impl<'a> Task<'a> {
     }
 }
 
+impl Drop for Task<'_> {
+    fn drop(&mut self) {
+        // Remove the local data set for the task
+        TASK_LOCAL_DATA_MAP.write().remove(&self.id);
+    }
+}
+
 /// A unique identifier for a task.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Identifier(usize);
@@ -97,6 +118,12 @@ impl Identifier {
     }
 }
 
+impl From<usize> for Identifier {
+    fn from(id: usize) -> Self {
+        Self(id)
+    }
+}
+
 impl From<Identifier> for usize {
     fn from(id: Identifier) -> usize {
         id.0
@@ -107,4 +134,109 @@ impl core::fmt::Display for Identifier {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
+}
+
+/// The local data set associated with a task. This data is specific to each
+/// task and is not shared between tasks, although a task can access the local
+/// data of other tasks through interior mutability.
+#[derive(Debug)]
+pub struct LocalDataSet {
+    /// A queue where this task can sleep waiting to receive an IPC message.
+    pub ipc_receive_queue: future::wait::Queue,
+
+    /// A queue where tasks that are waiting for a reply from this task can sleep.
+    pub ipc_reply_queue: future::wait::Queue,
+
+    /// A queue of tasks waiting to send IPC messages to this task.
+    pub ipc_send_queue: future::wait::Queue,
+
+    /// An incoming IPC message for the task.
+    pub ipc_message: spin::Mutex<Option<Box<ipc::message::Message>>>,
+
+    /// The reply message sent to this task.
+    pub ipc_reply: spin::Mutex<Option<Box<ipc::message::Message>>>,
+
+    /// The IPC state of the task.
+    pub ipc_waiting_state: spin::Mutex<ipc::message::IpcWaitingState>,
+}
+
+impl Default for LocalDataSet {
+    fn default() -> Self {
+        Self {
+            ipc_receive_queue: future::wait::Queue::new(),
+            ipc_reply_queue: future::wait::Queue::new(),
+            ipc_send_queue: future::wait::Queue::new(),
+            ipc_message: spin::Mutex::new(None),
+            ipc_reply: spin::Mutex::new(None),
+            ipc_waiting_state: spin::Mutex::new(ipc::message::IpcWaitingState::None),
+        }
+    }
+}
+
+impl Drop for LocalDataSet {
+    fn drop(&mut self) {
+        // Poison queues to prevent any new tasks from sleeping on it,
+        // then wake up all tasks waiting to send IPC messages to this task
+        // or waiting for a reply from this task to prevent them from being
+        // stuck forever.
+        self.ipc_reply_queue.poison();
+        self.ipc_reply_queue.wake_all();
+        self.ipc_send_queue.poison();
+        self.ipc_send_queue.wake_all();
+    }
+}
+
+/// Checks if a task with the given identifier exists. It verifies the
+/// existence of the local data set for the task, since the local data set is
+/// created and destroyed along with the task itself.
+pub fn exists(id: Identifier) -> bool {
+    let map = TASK_LOCAL_DATA_MAP.read();
+    map.contains_key(&id)
+}
+
+/// Executes a closure with access to the local data set of the task with
+/// the given identifier. If the task does not exist, `None` is passed to the
+/// closure.
+///
+/// Nested calls to this function are allowed, since the local data set is only
+/// borrowed for read access. Mutating the local data set must be done through
+/// interior mutability.
+pub fn try_with_local_set_from<F, R>(id: Identifier, f: F) -> R
+where
+    F: FnOnce(Option<&LocalDataSet>) -> R,
+{
+    let map = TASK_LOCAL_DATA_MAP.read();
+    let local_data_set = map.get(&id);
+    f(local_data_set)
+}
+
+/// Executes a closure with access to the local data set of the task with
+/// the given identifier. Nested calls to this function are allowed, since
+/// the local data set is only borrowed for read access. Mutating the local
+/// data set must be done through interior mutability.
+///
+/// # Panics
+/// Panics if the task with the given identifier does not exist.
+pub fn with_local_set_from<F, R>(id: Identifier, f: F) -> R
+where
+    F: FnOnce(&LocalDataSet) -> R,
+{
+    let map = TASK_LOCAL_DATA_MAP.read();
+    let local_data_set = map.get(&id).expect("Task local data set not found");
+    f(local_data_set)
+}
+
+/// Executes a closure with access to the local data set of the currently
+/// running task. Nested calls to this function are allowed, since the local
+/// data set is only borrowed for read access. Mutating the local data set must
+/// be done through interior mutability.
+///
+/// # Panics
+/// Panics if there is no currently running task.
+pub fn with_current_local_set<F, R>(f: F) -> R
+where
+    F: FnOnce(&LocalDataSet) -> R,
+{
+    let current_id = future::executor::current_task_id().unwrap();
+    with_local_set_from(current_id, f)
 }

--- a/kernel/src/future/task.rs
+++ b/kernel/src/future/task.rs
@@ -1,6 +1,6 @@
 use crate::{
-    arch,
     future::{executor::Executor, waker::Waker},
+    time,
 };
 use alloc::boxed::Box;
 use core::{
@@ -22,7 +22,7 @@ pub struct Task<'a> {
     /// amount of CPU time the task has consumed, in nanoseconds. However, it
     /// does not directly correspond to real time, as it depends on the lowest
     /// quantum of all tasks in the system when the task was created.
-    vruntime: usize,
+    vruntime: u64,
 
     /// The waker of the task.
     waker: Waker<'a>,
@@ -36,7 +36,7 @@ impl<'a> Task<'a> {
     pub fn new(
         executor: &'a Executor<'a>,
         future: Pin<Box<dyn Future<Output = ()> + Send>>,
-        vruntime: usize,
+        vruntime: u64,
     ) -> Self {
         let id = Identifier::generate();
         let waker = Waker::new(executor.ready_ids(), id);
@@ -51,6 +51,7 @@ impl<'a> Task<'a> {
 
     /// Polls the task and returns whether it has completed or not. It also updates
     /// the virtual runtime of the task based on the time spent in the poll.
+    #[allow(clippy::cast_possible_truncation)]
     pub fn poll(&mut self) -> core::task::Poll<()> {
         // SAFETY: This is safe because we have an exclusive access to the
         // task and by extension the waker. We also make sure that the
@@ -59,21 +60,19 @@ impl<'a> Task<'a> {
         // is in use.
         let waker = unsafe { core::task::Waker::from_raw(self.waker.raw()) };
         let context = &mut core::task::Context::from_waker(&waker);
-        let current = arch::timer::since_boot();
-        let output = self.future.as_mut().poll(context);
-        let elapsed = arch::timer::since_boot().saturating_sub(current);
-        self.vruntime += elapsed.as_nanos() as usize;
+        let (output, elapsed) = time::spent_into(|| self.future.as_mut().poll(context));
+        self.vruntime += elapsed.as_nanos() as u64;
         output
     }
 
     /// Sets the virtual runtime of the task.
-    pub(super) fn set_vruntime(&mut self, vruntime: usize) {
+    pub(super) fn set_vruntime(&mut self, vruntime: u64) {
         self.vruntime = vruntime;
     }
 
     /// Returns the virtual runtime of the task.
     #[must_use]
-    pub(super) fn vruntime(&self) -> usize {
+    pub(super) fn vruntime(&self) -> u64 {
         self.vruntime
     }
 

--- a/kernel/src/future/user.rs
+++ b/kernel/src/future/user.rs
@@ -63,6 +63,7 @@ pub async fn thread_loop(mut thread: arch::thread::Thread) {
                 // we reset its continuous execution time in order to give
                 // it a full quantum when it is rescheduled.
                 yield_once().await;
+                poll_generation = future::executor::poll_generation();
                 deadline = Instant::now() + THREAD_MAX_RUN_DURATION;
             }
             Resume::Fault => break Exit::Fault,

--- a/kernel/src/future/user.rs
+++ b/kernel/src/future/user.rs
@@ -4,9 +4,10 @@ use crate::{
         self,
         trap::{Resume, Trap},
     },
-    config,
+    config::THREAD_MAX_RUN_DURATION,
+    future,
+    time::Instant,
 };
-use core::time::Duration;
 
 /// Thread exit status
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -21,45 +22,38 @@ pub enum Exit {
 /// The thread execution loop future. This future runs the given thread
 /// until it terminates, either normally or due to a fault.
 pub async fn thread_loop(mut thread: arch::thread::Thread) {
-    let max_run_duration = Duration::from_millis(config::THREAD_MAX_RUN_DURATION);
-    let mut remaining = max_run_duration;
+    let mut poll_generation = future::executor::poll_generation();
+    let mut deadline = Instant::now() + THREAD_MAX_RUN_DURATION;
 
     let exit = loop {
         // Set the next timer event
-        arch::timer::next_event(remaining);
+        arch::timer::next_event(Instant::now().duration_until(deadline));
 
         // Execute the thread until it traps, and measure the elapsed time
         // to update the remaining quantum of continuous user execution.
-        let start = arch::timer::since_boot();
         let trap = arch::thread::execute(&mut thread);
-        let elapsed = arch::timer::since_boot().saturating_sub(start);
-        remaining = remaining.saturating_sub(elapsed);
 
         // Handle the trap and determine whether to continue executing
         // the thread or terminate it.
-        let start = arch::timer::since_boot();
         let mut resume = match trap {
             Trap::Exception => arch::trap::handle_exception(&mut thread),
             Trap::Interrupt => arch::trap::handle_interrupt(&mut thread),
             Trap::Syscall => arch::trap::handle_syscall(&mut thread).await,
         };
 
-        // If the quantum has expired, yield to the scheduler and reset
-        // the quantum. This ensures that threads are preempted after
-        // their maximum allowed continuous execution time without yielding.
-        if remaining.is_zero() {
-            log::trace!("Thread continuous execution runtime expired, yielding");
+        if future::executor::has_yielded(&poll_generation) {
+            // The executor has polled other tasks since we last checked,
+            // indicating that this task has yielded. Update the poll generation
+            // to the current one and reset the continuous execution quantum
+            // to the maximum.
+            poll_generation = future::executor::poll_generation();
+            deadline = Instant::now() + THREAD_MAX_RUN_DURATION;
+        } else if deadline.has_passed() {
+            // If the quantum has expired, yield to the scheduler and reset
+            // the quantum. This ensures that threads are preempted after
+            // their maximum allowed continuous execution time without yielding.
             resume = Resume::Yield;
         }
-
-        // Measures the time spent handling the trap to update the remaining
-        // quantum, to avoid giving extra time to threads that trap frequently.
-        // WARNING : Do not add too much code after this point that could take
-        // a long time to execute, as it will not be accounted for in the
-        // remaining quantum, potentially causing threads to exceed their
-        // allowed continuous execution time.
-        let elapsed = arch::timer::since_boot().saturating_sub(start);
-        remaining = remaining.saturating_sub(elapsed);
 
         match resume {
             Resume::Terminate(code) => break Exit::Terminate(code),
@@ -68,8 +62,8 @@ pub async fn thread_loop(mut thread: arch::thread::Thread) {
                 // the quantum because the thread voluntarily yielded, so
                 // we reset its continuous execution time in order to give
                 // it a full quantum when it is rescheduled.
-                remaining = max_run_duration;
                 yield_once().await;
+                deadline = Instant::now() + THREAD_MAX_RUN_DURATION;
             }
             Resume::Fault => break Exit::Fault,
             Resume::Continue => (),

--- a/kernel/src/future/user.rs
+++ b/kernel/src/future/user.rs
@@ -21,23 +21,58 @@ pub enum Exit {
 /// The thread execution loop future. This future runs the given thread
 /// until it terminates, either normally or due to a fault.
 pub async fn thread_loop(mut thread: arch::thread::Thread) {
+    let max_run_duration = Duration::from_millis(config::THREAD_MAX_RUN_DURATION);
+    let mut remaining = max_run_duration;
+
     let exit = loop {
         // Set the next timer event
-        arch::timer::next_event(Duration::from_millis(config::THREAD_QUANTUM));
+        arch::timer::next_event(remaining);
+
+        // Execute the thread until it traps, and measure the elapsed time
+        // to update the remaining quantum of continuous user execution.
+        let start = arch::timer::since_boot();
         let trap = arch::thread::execute(&mut thread);
-        let resume = match trap {
+        let elapsed = arch::timer::since_boot().saturating_sub(start);
+        remaining = remaining.saturating_sub(elapsed);
+
+        // Handle the trap and determine whether to continue executing
+        // the thread or terminate it.
+        let start = arch::timer::since_boot();
+        let mut resume = match trap {
             Trap::Exception => arch::trap::handle_exception(&mut thread),
             Trap::Interrupt => arch::trap::handle_interrupt(&mut thread),
             Trap::Syscall => arch::trap::handle_syscall(&mut thread).await,
         };
 
-        // TODO: Proper quantum management: if a thread yields, it should not
-        // consume its entire quantum.
+        // If the quantum has expired, yield to the scheduler and reset
+        // the quantum. This ensures that threads are preempted after
+        // their maximum allowed continuous execution time without yielding.
+        if remaining.is_zero() {
+            log::trace!("Thread continuous execution runtime expired, yielding");
+            resume = Resume::Yield;
+        }
+
+        // Measures the time spent handling the trap to update the remaining
+        // quantum, to avoid giving extra time to threads that trap frequently.
+        // WARNING : Do not add too much code after this point that could take
+        // a long time to execute, as it will not be accounted for in the
+        // remaining quantum, potentially causing threads to exceed their
+        // allowed continuous execution time.
+        let elapsed = arch::timer::since_boot().saturating_sub(start);
+        remaining = remaining.saturating_sub(elapsed);
+
         match resume {
             Resume::Terminate(code) => break Exit::Terminate(code),
-            Resume::Continue => (),
-            Resume::Yield => yield_once().await,
+            Resume::Yield => {
+                // Reset the quantum and yield to the scheduler. We reset
+                // the quantum because the thread voluntarily yielded, so
+                // we reset its continuous execution time in order to give
+                // it a full quantum when it is rescheduled.
+                remaining = max_run_duration;
+                yield_once().await;
+            }
             Resume::Fault => break Exit::Fault,
+            Resume::Continue => (),
         }
     };
 

--- a/kernel/src/future/wait.rs
+++ b/kernel/src/future/wait.rs
@@ -1,0 +1,82 @@
+use alloc::sync::Arc;
+use core::{
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+use crossbeam::queue::SegQueue;
+
+/// A wait queue that can hold wakers to be woken up later.
+#[derive(Default, Debug, Clone)]
+pub struct Queue {
+    waiting: Arc<SegQueue<Waker>>,
+}
+
+impl Queue {
+    /// Creates a new empty wait queue.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            waiting: Arc::new(SegQueue::new()),
+        }
+    }
+
+    /// Wake one waiting waker, if any.
+    pub fn wake_one(&self) {
+        if let Some(waker) = self.waiting.pop() {
+            waker.wake();
+        }
+    }
+
+    /// Wake all waiting wakers, emptying the queue.
+    pub fn wake_all(&self) {
+        while let Some(waker) = self.waiting.pop() {
+            waker.wake();
+        }
+    }
+}
+
+/// A future that waits on a wait queue until woken up.
+#[derive(Debug)]
+pub struct WaitFuture<'a> {
+    queue: &'a Queue,
+    pooled: bool,
+}
+
+impl<'a> WaitFuture<'a> {
+    /// Creates a new wait future associated with the given wait queue.
+    #[must_use]
+    pub const fn new(queue: &'a Queue) -> Self {
+        Self {
+            queue,
+            pooled: false,
+        }
+    }
+}
+
+impl Future for WaitFuture<'_> {
+    type Output = ();
+
+    /// Polls the wait future, registering the current waker to be woken
+    /// up later. If it was already registered, it returns `Poll::Ready(())`,
+    /// waking up the task immediately, even if not explicitly woken up by the
+    /// queue. Ensuring that the future was woken up by the queue is the caller's
+    /// responsibility, and would be too performance-costly to enforce here.
+    fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.pooled {
+            return Poll::Ready(());
+        }
+        self.queue.waiting.push(context.waker().clone());
+        self.get_mut().pooled = true;
+        Poll::Pending
+    }
+}
+
+/// Waits on the given wait queue until woken up.
+///
+/// # Spurious wake-ups
+/// This function may return even if not explicitly woken up by the queue. The
+/// caller must handle spurious wake-ups by checking the condition again, and
+/// calling this function again if necessary.
+pub async fn wait(queue: &Queue) {
+    WaitFuture::new(queue).await;
+}

--- a/kernel/src/future/wait.rs
+++ b/kernel/src/future/wait.rs
@@ -1,6 +1,7 @@
 use alloc::sync::Arc;
 use core::{
     pin::Pin,
+    sync::atomic::{AtomicBool, Ordering},
     task::{Context, Poll, Waker},
 };
 use crossbeam::queue::SegQueue;
@@ -9,6 +10,7 @@ use crossbeam::queue::SegQueue;
 #[derive(Default, Debug, Clone)]
 pub struct Queue {
     waiting: Arc<SegQueue<Waker>>,
+    poisoned: Arc<AtomicBool>,
 }
 
 impl Queue {
@@ -17,6 +19,7 @@ impl Queue {
     pub fn new() -> Self {
         Self {
             waiting: Arc::new(SegQueue::new()),
+            poisoned: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -32,6 +35,13 @@ impl Queue {
         while let Some(waker) = self.waiting.pop() {
             waker.wake();
         }
+    }
+
+    /// Poisons the wait queue, causing all future waiters to be woken up
+    /// immediately without sleeping. This is useful when the resource being
+    /// waited on is no longer available.
+    pub fn poison(&self) {
+        self.poisoned.store(true, Ordering::SeqCst);
     }
 }
 
@@ -61,11 +71,27 @@ impl Future for WaitFuture<'_> {
     /// waking up the task immediately, even if not explicitly woken up by the
     /// queue. Ensuring that the future was woken up by the queue is the caller's
     /// responsibility, and would be too performance-costly to enforce here.
+    ///
+    /// # Wait queue poisoning
+    /// If the wait queue was poisoned, the future returns `Poll::Ready(())`
+    /// immediately, without waiting. This allows tasks to be  woken up when
+    /// the resource they were waiting on is no longer available, without
+    /// getting stuck forever, but may lead to spurious wake-ups if the
+    /// queue was poisoned after registering the waker.
     fn poll(self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         if self.pooled {
             return Poll::Ready(());
         }
         self.queue.waiting.push(context.waker().clone());
+
+        // Check if the queue was poisoned after registering the waker to
+        // ensure that we will not miss a wake-up and prevent getting stuck
+        // forever. However, this may lead to spurious wake-ups if the queue
+        // was poisoned between the check and the registration, but should not
+        // be a problem since this situation should be very rare.
+        if self.queue.poisoned.load(Ordering::SeqCst) {
+            return Poll::Ready(());
+        }
         self.get_mut().pooled = true;
         Poll::Pending
     }

--- a/kernel/src/future/waker.rs
+++ b/kernel/src/future/waker.rs
@@ -5,7 +5,7 @@ use crossbeam::queue::ArrayQueue;
 /// A waker that can wake up a task.
 #[derive(Debug)]
 pub struct Waker {
-    /// The que to push the task identifier to when waking
+    /// The queue to push the task identifier to when waking
     /// up the task.
     queue: Arc<ArrayQueue<task::Identifier>>,
 

--- a/kernel/src/future/waker.rs
+++ b/kernel/src/future/waker.rs
@@ -1,50 +1,32 @@
 use super::task::{self};
-use core::task::{RawWaker, RawWakerVTable};
+use alloc::sync::Arc;
 use crossbeam::queue::ArrayQueue;
-
-static WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-    // Clone
-    |data| RawWaker::new(data.cast::<()>(), &WAKER_VTABLE),
-    // Wake
-    |data| unsafe {
-        let waker = &*(data.cast::<Waker>());
-        waker.queue.push(waker.id).expect("Queue is full");
-    },
-    // Wake by ref
-    |data| unsafe {
-        let waker = &*(data.cast::<Waker>());
-        waker.queue.push(waker.id).expect("Queue is full");
-    },
-    // Drop
-    |_| {},
-);
 
 /// A waker that can wake up a task.
 #[derive(Debug)]
-pub struct Waker<'a> {
+pub struct Waker {
     /// The que to push the task identifier to when waking
     /// up the task.
-    queue: &'a ArrayQueue<task::Identifier>,
+    queue: Arc<ArrayQueue<task::Identifier>>,
 
     /// The identifier of the task to wake up.
-    id: task::Identifier,
+    pub id: task::Identifier,
 }
 
-impl<'a> Waker<'a> {
+impl Waker {
     /// Create a new waker.
     #[must_use]
-    pub const fn new(queue: &'a ArrayQueue<task::Identifier>, id: task::Identifier) -> Self {
+    pub fn new(queue: Arc<ArrayQueue<task::Identifier>>, id: task::Identifier) -> Self {
         Waker { queue, id }
     }
+}
 
-    /// Create a raw waker from the waker.
-    ///
-    /// # Safety
-    /// The caller must ensure that the raw waker is not used after the
-    /// waker is dropped. The caller must also ensure to not create
-    /// mutable references to the waker while the raw waker is in use.
-    #[must_use]
-    pub(super) unsafe fn raw(&self) -> RawWaker {
-        RawWaker::new(core::ptr::from_ref(self).cast::<()>(), &WAKER_VTABLE)
+impl alloc::task::Wake for Waker {
+    fn wake(self: Arc<Self>) {
+        self.queue.push(self.id).expect("Queue is full");
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.queue.push(self.id).expect("Queue is full");
     }
 }

--- a/kernel/src/ipc/message.rs
+++ b/kernel/src/ipc/message.rs
@@ -1,36 +1,15 @@
-use alloc::vec::Vec;
-use hashbrown::HashMap;
+use alloc::boxed::Box;
 
-use crate::future;
+use crate::future::{self};
 
-/// The table that keeps track for a given receiver, which tasks have sent
-/// a message and are waiting for a reply.
-static PENDING_MESSAGE_TASKS: spin::Once<spin::Mutex<HashMap<usize, Vec<usize>>>> =
-    spin::Once::new();
-
-/// The global message storage that holds messages sent between processes. Our
-/// IPC mechanism is based on synchronous message passing, where a sender
-/// sends a message to a receiver and waits for a reply.
-static MESSAGES: spin::Once<spin::Mutex<HashMap<usize, Message>>> = spin::Once::new();
-
-/// The global receiver queues storage that holds the wait queues for each
-/// receiver process. This is used to wake up receivers when a new message
-/// arrives for them.
-static RECEIVERS_QUEUE: spin::Once<spin::Mutex<HashMap<usize, future::wait::Queue>>> =
-    spin::Once::new();
-
-/// Represents a message sent between processes.
+/// Represents a message sent between tasks.
 #[derive(Debug, Clone)]
 pub struct Message {
-    /// The sender's process identifier.
-    pub sender: usize,
+    /// The sender's task identifier.
+    pub sender: future::task::Identifier,
 
-    /// The receiver's process identifier.
-    pub receiver: usize,
-
-    /// The queue that the sender is using to wait for a reply. This is used
-    /// to notify the sender when a reply is available.
-    pub sender_queue: future::wait::Queue,
+    /// The receiver's task identifier.
+    pub receiver: future::task::Identifier,
 
     /// The operation code of the message. This defines the type of request
     /// or action that the sender wants the receiver to perform. This could
@@ -57,11 +36,52 @@ impl Message {
     pub const MAX_PAYLOAD_SIZE: usize = 256;
 }
 
+/// Represents the IPC waiting state of a task. This enum defines the
+/// different states a task can be when waiting for IPC operations.
+#[derive(Debug)]
+pub enum IpcWaitingState {
+    /// The task does not wait for anything.
+    None,
+
+    /// The task is waiting to send a message.
+    WaitingForSend,
+
+    /// The task is waiting to receive a message.
+    WaitingForMessage,
+
+    /// The task is waiting for a reply to a previously sent message by
+    /// the specified task identifier.
+    WaitingForReply(future::task::Identifier),
+}
+
+impl IpcWaitingState {
+    /// Sets the IPC state to `WaitingForReply`.
+    pub fn set_waiting_for_reply(&mut self, from: future::task::Identifier) {
+        *self = IpcWaitingState::WaitingForReply(from);
+    }
+
+    /// Sets the IPC state to `WaitingForMessage`
+    pub fn set_waiting_for_message(&mut self) {
+        *self = IpcWaitingState::WaitingForMessage;
+    }
+
+    /// Sets the IPC state to `WaitingForSend`.
+    pub fn set_waiting_for_send(&mut self) {
+        *self = IpcWaitingState::WaitingForSend;
+    }
+}
+
 /// Represents errors that can occur when sending a message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SendError {
     /// The payload size exceeds the maximum allowed size.
     PayloadTooLarge,
+
+    /// The target task does not exist.
+    TaskDoesNotExist,
+
+    /// The target task has been destroyed before the message could be sent.
+    TaskDestroyed,
 }
 
 /// Represents errors that can occur when replying to a message.
@@ -72,82 +92,152 @@ pub enum ReplyError {
 
     /// The receiver is not expecting a reply.
     NotWaitingForReply,
-}
 
-/// Initializes the IPC subsystem by setting up the necessary data structures.
-pub fn setup() {
-    PENDING_MESSAGE_TASKS.call_once(|| spin::Mutex::new(HashMap::new()));
-    RECEIVERS_QUEUE.call_once(|| spin::Mutex::new(HashMap::new()));
-    MESSAGES.call_once(|| spin::Mutex::new(HashMap::new()));
+    /// The receiver expected a reply from a different sender.
+    UnexpectedSender,
+
+    /// The target task does not exist.
+    TaskDoesNotExist,
+
+    /// The target task has been destroyed before the reply could be sent.
+    TaskDestroyed,
 }
 
 /// Sends a message from one process to another and waits until a reply is
-/// received. The function is asynchronous and yields control while waiting
-/// for the reply.
+/// received.
 ///
 /// # Errors
-/// Returns a [`SendError`] if the message could not be sent. Possible errors
-/// include:
-/// - [`SendError::PayloadTooLarge`]: The payload size exceeds the maximum
-///   allowed size. See [`Message::MAX_PAYLOAD_SIZE`] for the limit.
+/// Returns a [`SendError`] if the message could not be sent or if the reply
+/// could not be received (mostly due to the target task being destroyed
+/// before the operation could complete).
 ///
 /// # Panics
-/// Panics if the IPC subsystem has not been initialized.
+/// Panics if there is no current task context. This can only happen if this
+/// function is called during kernel initialization, before any tasks have been
+/// created, and is a serious programming error.
 pub async fn send(
-    from: usize,
-    to: usize,
+    to: future::task::Identifier,
     operation: usize,
     payload: &[u8],
-) -> Result<Message, SendError> {
+) -> Result<Box<Message>, SendError> {
     if payload.len() > Message::MAX_PAYLOAD_SIZE {
         return Err(SendError::PayloadTooLarge);
     }
 
+    // Check that the target task exists
+    if !future::task::exists(to) {
+        return Err(SendError::TaskDoesNotExist);
+    }
+
     // Create the message to be sent
-    let message = Message {
+    let from = future::executor::current_task_id().unwrap();
+    let message = Box::new(Message {
         sender: from,
         receiver: to,
         operation,
         payload_len: payload.len(),
-        sender_queue: future::wait::Queue::new(),
         payload: {
             let mut buf = [0; Message::MAX_PAYLOAD_SIZE];
             buf[..payload.len()].copy_from_slice(payload);
             buf
         },
-    };
+    });
 
-    // Clone the sender's queue to use it for waiting for the reply.
-    let sender_queue = message.sender_queue.clone();
+    // Send the message by changing the IPC state of the receiver process
+    // if it is waiting for messages. Otherwise, we change our own state to
+    // waiting for a reply, and wait until the receiver is ready to process it.
+    loop {
+        let send_queue = future::task::try_with_local_set_from(to, |set| {
+            if let Some(receiver_local_set) = set {
+                match &*receiver_local_set.ipc_waiting_state.lock() {
+                    IpcWaitingState::WaitingForMessage => {
+                        // The receiver is waiting for messages. Due to
+                        // borrowing rules, we cannot set the message directly
+                        // here since the compiler does not know that this
+                        // will be the last iteration before we break out of
+                        // the loop, and throws a borrow error. So we return
+                        // None to indicate that we can proceed to deliver
+                        // the message.
+                        Ok(None)
+                    }
+                    _ => Ok(Some(receiver_local_set.ipc_send_queue.clone())),
+                }
+            } else {
+                // The target task has been destroyed before we could
+                // send the message. Return an error to the caller.
+                Err(SendError::TaskDestroyed)
+            }
+        })?;
 
-    // Insert the message into the MESSAGES table and record that the sender
-    // is waiting for a reply from the receiver
-    get_message_storage().lock().insert(from, message);
-    get_pending_tasks_storage()
-        .lock()
-        .entry(to)
-        .or_default()
-        .push(from);
-
-    // Wake up the receiver if it is waiting for messages
-    if let Some(queue) = get_receivers_queue().lock().remove(&to) {
-        queue.wake_all();
+        if let Some(queue) = send_queue {
+            // The receiver was not waiting for messages. We need to wait
+            // until it is ready to receive our message. Set our IPC state
+            // to waiting for send and wait on the associated queue.
+            future::task::with_current_local_set(|current_local_set| {
+                current_local_set
+                    .ipc_waiting_state
+                    .lock()
+                    .set_waiting_for_send();
+            });
+            future::wait::wait(&queue).await;
+        } else {
+            future::task::try_with_local_set_from(to, |set| {
+                if let Some(receiver_local_set) = set {
+                    // Wake up the receiver since it is waiting for messages,
+                    // and deliver the message to the receiver's local data
+                    // set.
+                    receiver_local_set.ipc_message.lock().replace(message);
+                    receiver_local_set.ipc_receive_queue.wake_one();
+                    Ok(())
+                } else {
+                    // The target task has been destroyed before we could
+                    // send the message. Return an error to the caller.
+                    Err(SendError::TaskDestroyed)
+                }
+            })?;
+            break;
+        }
     }
 
-    // Wait for a reply by yielding until a message is available for the sender
+    // Now that the message has been sent, wait for the reply. Set our IPC
+    // state to waiting for reply and wait on the associated queue.
     loop {
-        // Check if there is a reply message for the sender.
-        {
-            let mut messages = get_message_storage().lock();
-            if let Some(reply) = messages.get(&from)
-                && reply.sender == to
-            {
-                return Ok(messages.remove(&from).unwrap());
+        let reply = future::task::with_current_local_set(|current_local_set| {
+            if let Some(reply) = current_local_set.ipc_reply.lock().take() {
+                // A reply has been received. Return it.
+                Ok(Some(reply))
+            } else if !future::task::exists(to) {
+                // The target task has been destroyed before sending
+                // the reply. Return an error to the caller.
+                Err(SendError::TaskDestroyed)
+            } else {
+                // No reply yet. Set the state to waiting for reply from the
+                // receiver process, and return the associated reply queue
+                // to wait on and be woken up when the reply arrives.
+                current_local_set
+                    .ipc_waiting_state
+                    .lock()
+                    .set_waiting_for_reply(to);
+                Ok(None)
             }
+        })?;
+
+        if let Some(reply) = reply {
+            break Ok(reply);
         }
 
-        // Sleep until woken up by the receiver when a reply is available.
-        future::wait::wait(&sender_queue).await;
+        // We are still waiting for the reply. Sleep and wait to be woken up
+        // when the reply arrives, or when the target task is destroyed.
+        let queue = future::task::try_with_local_set_from(to, |receiver_local_set| {
+            if let Some(set) = receiver_local_set {
+                Ok(set.ipc_reply_queue.clone())
+            } else {
+                // The target task has been destroyed before sending
+                // the reply. Return an error to the caller.
+                Err(SendError::TaskDestroyed)
+            }
+        })?;
+        future::wait::wait(&queue).await;
     }
 }
 
@@ -155,33 +245,30 @@ pub async fn send(
 /// asynchronous and yields control while waiting for a message to arrive.
 ///
 /// # Panics
-/// Panics if the IPC subsystem has not been initialized.
-pub async fn receive(to: usize) -> Message {
+/// Panics if there is no current task context. This can only happen if this
+/// function is called during kernel initialization, before any tasks have been
+/// created, and is a serious programming error.
+pub async fn receive() -> Box<Message> {
     loop {
-        // Check if there is a message for the receiver
-        if let Some(from) = get_pending_tasks_storage()
-            .lock()
-            .get_mut(&to)
-            .and_then(alloc::vec::Vec::pop)
-        {
-            // There is a message for the receiver. Duplicate it and return it.
-            // Why clone? Because we need to keep the message in the MESSAGES table
-            // until the reply is sent back to the sender.
-            if let Some(message) = get_message_storage().lock().get(&from) {
-                return message.clone();
-            }
+        // Check if there is a message for the receiver.
+        let message = future::task::with_current_local_set(|current_local_set| {
+            current_local_set.ipc_message.lock().take()
+        });
 
-            // This should not happen, as we have a pending task for this
-            // receiver, but no message. Log an error and continue waiting.
-            log::error!(
-                "Inconsistent state: pending task {:?} for receiver {:?} but no message",
-                from,
-                to
-            );
+        // Yes, a message is available. Return it.
+        if let Some(message) = message {
+            break message;
         }
 
-        // Sleep until woken up by a sender when a new message arrives.
-        let queue = get_receivers_queue().lock().entry(to).or_default().clone();
+        // No message available yet. Change the IPC state to indicate that we
+        // are waiting for a message, wake up any senders waiting to send us
+        // messages, and wait on our receive queue to be woken up when a
+        // message arrives.
+        let queue = future::task::with_current_local_set(|local_set| {
+            local_set.ipc_waiting_state.lock().set_waiting_for_message();
+            local_set.ipc_send_queue.wake_all();
+            local_set.ipc_receive_queue.clone()
+        });
         future::wait::wait(&queue).await;
     }
 }
@@ -189,80 +276,68 @@ pub async fn receive(to: usize) -> Message {
 /// Sends a reply message from one process to another.
 ///
 /// # Errors
-/// Returns a `ReplyError` if the reply could not be sent. Possible errors
-/// include:
-/// - [`ReplyError::PayloadTooLarge`]: The payload size exceeds the maximum allowed size.
-/// - [`ReplyError::NotWaitingForReply`]: The receiver is not expecting a reply from the
-///   sender. This usually means that there was no prior message sent from the
-///   sender to the receiver.
+/// Returns a [`ReplyError`] if the reply could not be sent.
 ///
 /// # Panics
-/// Panics if the IPC subsystem has not been initialized.
-pub fn reply(from: usize, to: usize, status: usize, payload: &[u8]) -> Result<(), ReplyError> {
+/// Panics if there is no current task context. This can only happen if this
+/// function is called during kernel initialization, before any tasks have been
+/// created, and is a serious programming error.
+pub fn reply(
+    to: future::task::Identifier,
+    status: usize,
+    payload: &[u8],
+) -> Result<(), ReplyError> {
     if payload.len() > Message::MAX_PAYLOAD_SIZE {
         return Err(ReplyError::PayloadTooLarge);
     }
 
-    // Check if the receiver is waiting for a reply. We can know this by
-    // checking if there is a message stored for the receiver in the MESSAGES
-    // table. We ensure that the sender is indeed the one waiting for the reply.
-    let mut messages = get_message_storage().lock();
-    match messages.get(&to) {
-        Some(msg) => {
-            if msg.receiver != from {
-                return Err(ReplyError::NotWaitingForReply);
-            }
-            msg.sender_queue.wake_all();
-        }
-        None => return Err(ReplyError::NotWaitingForReply),
+    if !future::task::exists(to) {
+        return Err(ReplyError::TaskDoesNotExist);
     }
 
-    // Remove the original message from the storage
-    messages.remove(&to);
-
     // Create the reply message
-    let mut message = Message {
+    let from = future::executor::current_task_id().unwrap();
+    let message = Box::new(Message {
         sender: from,
         receiver: to,
         operation: status,
         payload_len: payload.len(),
-        payload: [0; Message::MAX_PAYLOAD_SIZE],
-        sender_queue: future::wait::Queue::new(),
-    };
+        payload: {
+            let mut buf = [0; Message::MAX_PAYLOAD_SIZE];
+            buf[..payload.len()].copy_from_slice(payload);
+            buf
+        },
+    });
 
-    // Copy the payload into the message and insert it into the
-    // MESSAGES table for the receiver to pick up later
-    message.payload[..payload.len()].copy_from_slice(payload);
-    messages.insert(to, message);
+    // Check if the receiver is waiting for a reply by checking its IPC state,
+    // and ensure that it is waiting for a reply from the correct sender. If
+    // so, deliver the reply message and wake up the receiver.
+    future::task::try_with_local_set_from(to, |set| {
+        if let Some(receiver_local_set) = set {
+            match *receiver_local_set.ipc_waiting_state.lock() {
+                IpcWaitingState::WaitingForReply(expected_from) => {
+                    if expected_from != from {
+                        return Err(ReplyError::UnexpectedSender);
+                    }
+                    receiver_local_set.ipc_reply.lock().replace(message);
+                    Ok(())
+                }
+                _ => Err(ReplyError::NotWaitingForReply),
+            }
+        } else {
+            // The target task has been destroyed before we could
+            // send the reply. Return an error to the caller.
+            Err(ReplyError::TaskDestroyed)
+        }
+    })?;
+
+    // Since we can't know which task will be woken up (in case of multiple
+    // tasks waiting for a reply), we wake them all up. This can happen if
+    // the task handle multiple IPC receives before replying to any of them.
+    // TODO: Only wake up the task that we replied to.
+    future::task::with_current_local_set(|current_local_set| {
+        current_local_set.ipc_reply_queue.wake_all();
+    });
+
     Ok(())
-}
-
-/// An helper function to get a reference to the global MESSAGES storage.
-///
-/// # Panics
-/// Panics if the IPC subsystem has not been initialized.
-fn get_message_storage() -> &'static spin::Mutex<HashMap<usize, Message>> {
-    MESSAGES.get().expect("MESSAGES not initialized")
-}
-
-/// An helper function to get a reference to the global `PENDING_MESSAGE_TASKS`
-/// storage.
-///
-/// # Panics
-/// Panics if the IPC subsystem has not been initialized.
-fn get_pending_tasks_storage() -> &'static spin::Mutex<HashMap<usize, Vec<usize>>> {
-    PENDING_MESSAGE_TASKS
-        .get()
-        .expect("PENDING_MESSAGE_TASKS not initialized")
-}
-
-/// An helper function to get a reference to the global `RECEIVERS_QUEUE`
-/// storage.
-///
-/// # Panics
-/// Panics if the IPC subsystem has not been initialized.
-fn get_receivers_queue() -> &'static spin::Mutex<HashMap<usize, future::wait::Queue>> {
-    RECEIVERS_QUEUE
-        .get()
-        .expect("RECEIVER_QUEUE not initialized")
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -62,7 +62,6 @@ pub unsafe extern "Rust" fn kiwi(memory: arch::memory::UsableMemory) -> ! {
     future::executor::spawn(user::elf::load(&ECHO));
 
     ipc::service::setup();
-    ipc::message::setup();
 
     let memory_usage = mm::phys::kernel_memory_pages() * 4;
     log::info!("Boot completed !");

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -13,6 +13,7 @@ pub mod config;
 pub mod future;
 pub mod ipc;
 pub mod mm;
+pub mod time;
 pub mod user;
 pub mod utils;
 

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -1,0 +1,100 @@
+use core::{
+    ops::{Add, AddAssign, Sub, SubAssign},
+    time::Duration,
+};
+
+use crate::arch;
+
+/// A measurement of a monotonically nondecreasing clock. This is very
+/// similar to `std::time::Instant`, but tailored for kernel use.
+///
+/// # Panics
+/// Operations on `Instant` are guaranteed to never panic in real-world usage,
+/// but MAY panic in extremely unlikely edge cases, such as the underlying
+/// architecture's timer overflowing an u64 nanosecond representation, which
+/// would require the system to be running for approximately 584 years without
+/// rebooting. I will be dead way before that happens, so I will let future
+/// maintainers deal with that problem if it ever arises :)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Instant(u64);
+
+impl Instant {
+    /// Returns an instant corresponding to "now".
+    ///
+    /// # Panics
+    /// This function MAY panic if the underlying architecture's timer overflows
+    /// an u64 nanosecond representation. This is highly unlikely to happen in
+    /// practice, since it would require the system to be running for hundreds
+    /// of years without rebooting.
+    #[must_use]
+    pub fn now() -> Self {
+        Instant(arch::timer::current_time_ticks() * arch::timer::internal_tick())
+    }
+
+    /// Returns the duration elapsed since this instant.
+    #[must_use]
+    pub fn elapsed(&self) -> Duration {
+        Instant::now().duration_since(*self)
+    }
+
+    /// Returns whether this instant has already passed.
+    #[must_use]
+    pub fn has_passed(&self) -> bool {
+        Instant::now() >= *self
+    }
+
+    /// Returns the duration elapsed since the earlier instant. If `earlier`
+    /// is later than `self`, the returned duration will be zero.
+    #[must_use]
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        Duration::from_nanos(self.0.saturating_sub(earlier.0))
+    }
+
+    /// Returns the duration until the later instant. If `later` is earlier
+    /// than `self`, the returned duration will be zero.
+    #[must_use]
+    pub fn duration_until(&self, later: Instant) -> Duration {
+        Duration::from_nanos(later.0.saturating_sub(self.0))
+    }
+}
+
+impl Add<Duration> for Instant {
+    type Output = Instant;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn add(self, duration: Duration) -> Instant {
+        Instant(self.0.saturating_add(duration.as_nanos() as u64))
+    }
+}
+
+impl Sub<Duration> for Instant {
+    type Output = Instant;
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn sub(self, duration: Duration) -> Instant {
+        Instant(self.0.saturating_sub(duration.as_nanos() as u64))
+    }
+}
+
+impl AddAssign<Duration> for Instant {
+    #[allow(clippy::cast_possible_truncation)]
+    fn add_assign(&mut self, duration: Duration) {
+        self.0 = self.0.saturating_add(duration.as_nanos() as u64);
+    }
+}
+
+impl SubAssign<Duration> for Instant {
+    #[allow(clippy::cast_possible_truncation)]
+    fn sub_assign(&mut self, duration: Duration) {
+        self.0 = self.0.saturating_sub(duration.as_nanos() as u64);
+    }
+}
+
+/// Measures the time taken to execute the provided closure, returning both
+/// the result of the closure and the duration it took to execute.
+#[must_use]
+pub fn spent_into<T>(f: impl FnOnce() -> T) -> (T, Duration) {
+    let start = Instant::now();
+    let result = f();
+    (result, start.elapsed())
+}

--- a/kernel/src/user/ptr.rs
+++ b/kernel/src/user/ptr.rs
@@ -1,7 +1,14 @@
-use crate::arch::riscv64::addr::{Virtual, virt::User};
+use crate::arch::{
+    riscv64::addr::{Virtual, virt::User},
+    thread::Thread,
+};
 
 /// This structure encapsulate a pointer to an object in the userland memory:
-/// this structure guarantees that the pointer is in the userland memory.
+/// this structure guarantees that the pointer is in the userland memory. It
+/// also contains the thread that owns the userland memory, so that we can
+/// access the userland memory safely and can change to the correct address
+/// space lazily when we need to access the userland memory, allowing us to
+/// avoid unnecessary context switches.
 ///
 /// # Data Races
 /// Contrary to the kernel, data races are allowed in the userland memory. This
@@ -12,7 +19,8 @@ use crate::arch::riscv64::addr::{Virtual, virt::User};
 /// not all user applications are written in Rust and follow the Rust memory
 /// safety rules.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Pointer<T> {
+pub struct Pointer<'a, T> {
+    thread: &'a Thread,
     inner: *mut T,
 }
 
@@ -21,21 +29,21 @@ pub struct Pointer<T> {
 /// allowed in the userland memory since it is outside of the kernel control.
 /// Therefore, sending a `Pointer<T>` between threads does not violate any memory
 /// safety rules.
-unsafe impl<T: Send> Send for Pointer<T> {}
+unsafe impl<T: Send> Send for Pointer<'_, T> {}
 
-impl<T> Pointer<T> {
+impl<'a, T> Pointer<'a, T> {
     /// Tries to create a new user pointer. Returns `None` if the given pointer
     /// is not fully in the userland memory. This is equivalent to calling
     /// `Pointer::array` with a length of 1.
     #[must_use]
-    pub fn new(ptr: *mut T) -> Option<Self> {
-        Self::array(ptr, 1)
+    pub fn new(thread: &'a Thread, ptr: *mut T) -> Option<Self> {
+        Self::array(thread, ptr, 1)
     }
 
     /// Tries to create a new user pointer to an array of `len` elements. Returns
     /// `None` if the given pointer is not fully in the userland memory.
     #[must_use]
-    pub fn array(ptr: *mut T, len: usize) -> Option<Self> {
+    pub fn array(thread: &'a Thread, ptr: *mut T, len: usize) -> Option<Self> {
         let start = Virtual::<User>::try_new(ptr.cast::<u8>().addr());
         let end = Virtual::<User>::try_new(
             ptr.cast::<u8>()
@@ -50,9 +58,15 @@ impl<T> Pointer<T> {
         if let (Some(start), Some(end)) = (start, end)
             && start <= end
         {
-            return Some(Self { inner: ptr });
+            return Some(Self { thread, inner: ptr });
         }
         None
+    }
+
+    /// Get the thread that owns the userland memory.
+    #[must_use]
+    pub fn thread(&self) -> &'a Thread {
+        self.thread
     }
 
     /// Get the raw pointer to the object in the userland memory.
@@ -62,7 +76,7 @@ impl<T> Pointer<T> {
     }
 }
 
-impl<T> core::fmt::Display for Pointer<T> {
+impl<T> core::fmt::Display for Pointer<'_, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "0x{:016x}", self.inner.addr())
     }

--- a/kernel/src/user/syscall/service.rs
+++ b/kernel/src/user/syscall/service.rs
@@ -1,5 +1,5 @@
 use crate::{
-    arch::trap::Resume,
+    arch::{thread::Thread, trap::Resume},
     future, ipc,
     user::{self, syscall::SyscallReturnValue},
 };
@@ -31,10 +31,11 @@ impl From<ipc::service::ServiceRegisterError> for ::syscall::service::RegisterEr
 ///   never happen since service registration must be done within a task
 ///   context).
 pub fn register(
+    thread: &Thread,
     name_ptr: *mut u8,
     name_len: usize,
 ) -> Result<SyscallReturnValue, ::syscall::service::RegisterError> {
-    let name = user::string::String::new(name_ptr, name_len)
+    let name = user::string::String::new(thread, name_ptr, name_len)
         .ok_or(::syscall::service::RegisterError::BadName)?
         .fetch()
         .map_err(|_| ::syscall::service::RegisterError::BadName)?;
@@ -73,10 +74,11 @@ pub fn unregister() -> Result<SyscallReturnValue, ::syscall::service::Unregister
 /// sense, but rather a lookup of the service ID, no actual connection state
 /// is maintained, and thus no disconnection is necessary.
 pub fn connect(
+    thread: &Thread,
     name_ptr: *mut u8,
     name_len: usize,
 ) -> Result<SyscallReturnValue, ::syscall::service::ConnectionError> {
-    let name = user::string::String::new(name_ptr, name_len)
+    let name = user::string::String::new(thread, name_ptr, name_len)
         .ok_or(::syscall::service::ConnectionError::BadName)?
         .fetch()
         .map_err(|_| ::syscall::service::ConnectionError::BadName)?;


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the kernel's memory management, task scheduling, and timing infrastructure. The most significant changes include enhancements to the page table management for RISC-V, a refactor of the executor to support fairer scheduling via virtual runtimes, and more expressive error handling in the IPC subsystem.

**Kernel Memory Management (RISC-V Page Table):**
- Refactored the kernel's root page table (`KERNEL_TABLE`) to use `spin::Once` for safer initialization, and updated all usages accordingly. Added methods for accessing the address space and kernel space, and made the `Table` type `!Unpin` using `PhantomPinned` for safety. [[1]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL41-R43) [[2]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL58-R54) [[3]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daR64-R78) [[4]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daR87-R94) [[5]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daR108-R112) [[6]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daR125-R130) [[7]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL134-L139) [[8]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL171-R189) [[9]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL519-R532) [[10]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL582-R595) [[11]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daL649-R662) [[12]](diffhunk://#diff-68474ec2dabe55eb0f56a3f01ea12f4c5269351da4158bab465ba372e5fc80daR725-R729)

**Task Scheduling and Executor Refactor:**
- Replaced the FIFO executor queue with a fairer scheduler using virtual runtimes. Introduced `ready_queue` (a `BTreeMap` keyed by virtual runtime) and a secondary `ready_ids` queue to minimize locking. Added a global poll generation counter for tracking executor progress. [[1]](diffhunk://#diff-a23f6824098cba125695630dd7511e530f17216ebb1c8b023cab7d5376c9e6ffL1-R9) [[2]](diffhunk://#diff-a23f6824098cba125695630dd7511e530f17216ebb1c8b023cab7d5376c9e6ffR22-R33) [[3]](diffhunk://#diff-a23f6824098cba125695630dd7511e530f17216ebb1c8b023cab7d5376c9e6ffL47-R63) [[4]](diffhunk://#diff-a23f6824098cba125695630dd7511e530f17216ebb1c8b023cab7d5376c9e6ffL58-L67) [[5]](diffhunk://#diff-a23f6824098cba125695630dd7511e530f17216ebb1c8b023cab7d5376c9e6ffR87-R90) [[6]](diffhunk://#diff-a23f6824098cba125695630dd7511e530f17216ebb1c8b023cab7d5376c9e6ffL89)

**IPC Error Handling Improvements:**
- Added new error variants to `SendError` and `ReplyError` enums to distinguish between non-existent and destroyed tasks, as well as unexpected senders. Updated their conversions to `isize` for syscall compatibility. [[1]](diffhunk://#diff-69c001efaf232011271eedb5505d42eb6ff6d822ae59f9f4e573bbede6647c63R60-R65) [[2]](diffhunk://#diff-69c001efaf232011271eedb5505d42eb6ff6d822ae59f9f4e573bbede6647c63R75-R76) [[3]](diffhunk://#diff-69c001efaf232011271eedb5505d42eb6ff6d822ae59f9f4e573bbede6647c63R117-R125) [[4]](diffhunk://#diff-69c001efaf232011271eedb5505d42eb6ff6d822ae59f9f4e573bbede6647c63R136-R138)

**Timer and Timekeeping Enhancements:**
- Introduced new functions (`current_time_ticks`, `since_boot`) for precise time measurement since system boot, available both generically and for RISC-V. [[1]](diffhunk://#diff-e2fca23704644681b3f73fd3feed50b7e2a6ac7e49f9744d4e2ccb350ab7bf3fR28-R42) [[2]](diffhunk://#diff-645c73836fab35863ffd5c22247e08a311ad204e8f9000f77518f2f99add9b85R66-R71)

**Configuration and Scheduling Quantum:**
- Changed the thread scheduling quantum from a raw millisecond value to a `core::time::Duration` constant (`THREAD_MAX_RUN_DURATION`), improving clarity and type safety. [[1]](diffhunk://#diff-262d8f86d14231dc2d2af7b991965158cd00a57c0c0504a50c74af6bca0f2352R1-R2) [[2]](diffhunk://#diff-262d8f86d14231dc2d2af7b991965158cd00a57c0c0504a50c74af6bca0f2352L22-R36)

These changes collectively improve kernel safety, error reporting, scheduling fairness, and time management.